### PR TITLE
tiny fix for an import warning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.md linguist-language=Markdown
+*.markdown linguist-language=Markdown

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -5,4 +5,4 @@
 // Override minima theme variables before importing
 $on-palm: 800px; /* Changed for feedback button */
 
-@import "minima";
+@use "minima";


### PR DESCRIPTION
1. Deprecation Warning: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
4 │ @import "minima";
  │         ^^^^^^^^
  ╵

2. Given that there are several markdown related documentation. Perhaps, it is a good idea to add that statistics in the github repository (?)